### PR TITLE
don't resize images if they are a duplicate size

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,11 +71,20 @@ module.exports = function(content) {
     }
 
     var q = queue();
-    
+    var widthsToGenerate = [];
+
     (Array.isArray(sizes) ? sizes : [sizes]).forEach(function(size) {
       var width = Math.min(img.bitmap.width, parseInt(size, 10));
+      // This is a "shorthand" for array.prototype.includes() for places that don't support it.
+      // It returns true if the item exists in the array, false otherwise.
+      var widthExists = !!~widthsToGenerate.indexOf(width);
 
-      q.defer(resizeImage, width);
+      // Only resize images if they aren't an exact copy of one already being resized...
+      if (!widthExists) {
+        widthsToGenerate.push(width);
+        q.defer(resizeImage, width);
+      }
+
     });
 
     q.awaitAll(function(err, files) {
@@ -88,7 +97,7 @@ module.exports = function(content) {
       }).join(',');
 
       var firstImagePath = files[0].path;
-      
+
       loaderCallback(null, 'module.exports = {srcSet:' + srcset + ',images:[' + images + '],src:' + firstImagePath + ',toString:function(){return ' + firstImagePath + '}};');
     });
   });

--- a/index.js
+++ b/index.js
@@ -71,17 +71,14 @@ module.exports = function(content) {
     }
 
     var q = queue();
-    var widthsToGenerate = [];
+    var widthsToGenerate = new Set();
 
     (Array.isArray(sizes) ? sizes : [sizes]).forEach(function(size) {
       var width = Math.min(img.bitmap.width, parseInt(size, 10));
-      // This is a "shorthand" for array.prototype.includes() for places that don't support it.
-      // It returns true if the item exists in the array, false otherwise.
-      var widthExists = !!~widthsToGenerate.indexOf(width);
 
       // Only resize images if they aren't an exact copy of one already being resized...
-      if (!widthExists) {
-        widthsToGenerate.push(width);
+      if (!widthsToGenerate.has(width)) {
+        widthsToGenerate.add(width);
         q.defer(resizeImage, width);
       }
 


### PR DESCRIPTION
This is just a quick change to avoid re-creating multiple srcSets for an image if it already exists.

Basically, i found that if i applied the sizes [100, 1000, 10000] to an image that was 1000px wide, i would get [100w, 1000w, 1000w] as the "output" srcsets.

I thought this was a bit wasteful both in the time it takes and the output html, so this small change just has it ignore any duplicate sizes.

As a quick note, the `!!~widthsToGenerate.indexOf(width);` line is a bit convoluted looking, but it's just a shorthand for `widthsToGenerate.includes(width);`. I'm not sure what version of node array.prototype.includes was added in, and i'm not sure what version you are targeting here, so i decided to play it safe and stick with the "ES5" version of it.