### PR TITLE
fixes error raised when an error is handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function(content) {
 
   jimp.read(loaderContext.resourcePath, function(err, img) {
     if (err) {
-      return queueCallback(err);
+      return loaderCallback(err);
     }
 
     function resizeImage(width, queueCallback) {


### PR DESCRIPTION
When there's an error reading a resource path, the loader breaks trying to call an undefined function (`queueCallback`). This fixes that.